### PR TITLE
peg zig version to 0.11.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: master
+        zig-version: 0.11.0
 
     - name: Build
       run: zig build
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: master
+        zig-version: 0.11.0
 
     - name: Lint
       run: zig fmt --check src/*.zig
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: master
+        zig-version: 0.11.0
 
     - name: Test
       run: zig build test


### PR DESCRIPTION
This is a test to attempt to figure out why the CI tests don't run in #6.