### PR TITLE
fix name: decodeRLPAndHash -> encodeToRLPAndHash

### DIFF
--- a/src/blockchain/blockchain.zig
+++ b/src/blockchain/blockchain.zig
@@ -89,7 +89,7 @@ pub const Blockchain = struct {
         // TODO: this can be done more efficiently with some ring buffer to avoid copying the slice
         // to make room for the new block hash.
         std.mem.copyForwards(Hash32, &self.last_256_blocks_hashes, self.last_256_blocks_hashes[1..255]);
-        self.last_256_blocks_hashes[255] = try common.decodeRLPAndHash(BlockHeader, allocator, block.header, null);
+        self.last_256_blocks_hashes[255] = try common.encodeToRLPAndHash(BlockHeader, allocator, block.header, null);
 
         // Note that we free and clone with the Blockchain allocator, and not the arena allocator.
         // This is required since Blockchain field lifetimes are longer than the block execution processing.
@@ -134,7 +134,7 @@ pub const Blockchain = struct {
         if (!std.mem.eql(u8, &curr_block.uncle_hash, &blocks.empty_uncle_hash))
             return error.InvalidUnclesHash;
 
-        const prev_block_hash = try common.decodeRLPAndHash(BlockHeader, allocator, prev_block, null);
+        const prev_block_hash = try common.encodeToRLPAndHash(BlockHeader, allocator, prev_block, null);
         if (!std.mem.eql(u8, &curr_block.parent_hash, &prev_block_hash))
             return error.InvalidParentHash;
     }

--- a/src/common/common.zig
+++ b/src/common/common.zig
@@ -18,7 +18,7 @@ pub const AddressKeySet = std.AutoHashMap(AddressKey, void);
 
 // RLP
 pub const decodeRLP = rlp.decodeRLP;
-pub const decodeRLPAndHash = rlp.decodeRLPAndHash;
+pub const encodeToRLPAndHash = rlp.encodeToRLPAndHash;
 
 // Address
 pub const computeCREATEContractAddress = contract.computeCREATEContractAddress;

--- a/src/common/rlp.zig
+++ b/src/common/rlp.zig
@@ -11,7 +11,7 @@ pub fn decodeRLP(comptime T: type, arena: Allocator, bytes: []const u8) !T {
     return ret;
 }
 
-pub fn decodeRLPAndHash(comptime T: type, allocator: Allocator, value: T, prefix: ?[]const u8) !Hash32 {
+pub fn encodeToRLPAndHash(comptime T: type, allocator: Allocator, value: T, prefix: ?[]const u8) !Hash32 {
     var out = std.ArrayList(u8).init(allocator);
     defer out.deinit();
     try rlp.serialize(T, allocator, value, &out);

--- a/src/types/transaction.zig
+++ b/src/types/transaction.zig
@@ -183,7 +183,7 @@ pub const LegacyTx = struct {
     pub fn hash(self: LegacyTx, allocator: Allocator) !Hash32 {
         // TODO: consider caching the calculated txHash to avoid further
         // allocations and keccaking. But be careful since struct fields are public.
-        return try common.decodeRLPAndHash(LegacyTx, allocator, self, null);
+        return try common.encodeToRLPAndHash(LegacyTx, allocator, self, null);
     }
 
     pub fn setSignature(self: *LegacyTx, v: u256, r: u256, s: u256) void {
@@ -224,7 +224,7 @@ pub const AccessListTx = struct {
         // TODO: consider caching the calculated txHash to avoid further
         // allocations and keccaking. But be careful since struct fields are public.
         const prefix = [_]u8{@intFromEnum(TxTypes.AccessListTx)};
-        return try common.decodeRLPAndHash(AccessListTx, allocator, self, &prefix);
+        return try common.encodeToRLPAndHash(AccessListTx, allocator, self, &prefix);
     }
 
     pub fn setSignature(self: *AccessListTx, v: u256, r: u256, s: u256) void {
@@ -257,7 +257,7 @@ pub const FeeMarketTx = struct {
         // TODO: consider caching the calculated txHash to avoid further
         // allocations and keccaking. But be careful since struct fields are public.
         const prefix = [_]u8{@intFromEnum(TxTypes.FeeMarketTx)};
-        return try common.decodeRLPAndHash(FeeMarketTx, allocator, self, &prefix);
+        return try common.encodeToRLPAndHash(FeeMarketTx, allocator, self, &prefix);
     }
 
     pub fn setSignature(self: *FeeMarketTx, v: u256, r: u256, s: u256) void {


### PR DESCRIPTION
While working on my fork manager + eip 2935 implementation, I found that this method name is incorrect: it serializes an object to RLP and hashes it.